### PR TITLE
Fixes locales

### DIFF
--- a/app/views/spree/admin/digitals/index.html.erb
+++ b/app/views/spree/admin/digitals/index.html.erb
@@ -6,9 +6,9 @@
     <%= render 'form', :variant => variant %>
   <% end %>
 <% else %>
-  This product has no variants.
+ <span><%= t('spree.digitals.product_no_variants') %></span>
  <% if @product.master.digital? %>
-    A digital version of this product currently exists:
+    <span><%= t('spree.digitals.product_with_variants') %></span>
     <%= render @product.master.digitals %>
   <% end %>
   <%= render 'form', :variant => @product.master %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,3 +28,5 @@ en:
         unauthorized: Unauthorized
       upload: Upload
       file_name: File name
+      product_no_variants: This product has no variants.
+      product_with_variants: "A digital version of this product currently exists:"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,25 +1,28 @@
 es:
-  broken_file: ¡Atención! Este archivo está corrupto
-  current_file: Archivo actual
-  delete_file: Borrar este archivo
-  delete_file_confirmation: ¿Está seguro de que quiere borrar este fichero %{filename}?
-  digital_delivery: Entrega digital
-  digital_download: Descarga %{filename} ↓
-  digital_download_links: Enlaces para la descaga digital
-  file_is_not_ready: File is processing, please stand by
-  digital_format:
-    mp3: Audio MP3
-    mobi: Kindle eBook
-    epub: ePub eBook
-    pdf: pdf eBook
-  digital_versions: Versiones digitales
-  downloads_reset: Reset de descargas digitales
-  new_file: Nuevo Archivo
-  reset_downloads: Resetear descargas digitales
   spree:
     digitals:
+      broken_file: ¡Atención! Este archivo está corrupto
+      current_file: Archivo actual
+      delete_file: Borrar este archivo
+      delete_file_confirmation: ¿Está seguro de que quiere borrar este fichero %{filename}?
+      digital_delivery: Entrega digital
+      digital_download: Descarga %{filename}
+      digital_download_links: Enlaces para la descaga digital
+      file_is_not_ready: File is processing, please stand by
+      digital_format:
+        mp3: Audio MP3
+        mobi: Kindle eBook
+        epub: ePub eBook
+        pdf: pdf eBook
+      digital_versions: Versiones Digitales
+      downloads_reset: Reset de descargas digitales
+      files: Archivos
+      file_name: Nombre de Archivo
+      new_file: Nuevo Archivo
+      reset_downloads: Resetear descargas digitales
       unauthorized:
         explained: El enlace para la descarga ha expirado
         unauthorized: No estás autorizado
-  solidus_digital:
-    upload: Subir
+      upload: Subir
+      product_no_variants: Este Producto no tiene variantes
+      product_with_variants: "Este producto tiene versión digital:"

--- a/spec/controllers/admin/digitals_controller_spec.rb
+++ b/spec/controllers/admin/digitals_controller_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe Spree::Admin::DigitalsController do
       it "displays an empty page when the master variant is not digital" do
         get :index, params: { product_id: product.slug }
         expect(response.code).to eq("200")
-        expect(response.body).to include("This product has no variants")
-        expect(response.body).not_to include('A digital version of this product currently exists')
+        expect(response.body).to include("<span>This product has no variants.</span>")
+        expect(response.body).not_to include('<span>A digital version of this product currently exists:</span>')
       end
 
       it "displays the variant details when the master is digital" do
@@ -47,7 +47,7 @@ RSpec.describe Spree::Admin::DigitalsController do
         get :index, params: { product_id: product.slug }
 
         expect(response.code).to eq("200")
-        expect(response.body).to include('A digital version of this product currently exists')
+        expect(response.body).to include('<span>A digital version of this product currently exists:</span>')
       end
     end
   end


### PR DESCRIPTION
Hello

This PR fixes all the keys for the `es.yml` file as all of them were missing the root element `spree.digitals`.

Also fixes some issues with hardcoded values in one of the pages so it takes into account now the translation keys.
