### PR TITLE
Fixes redirection after reset

### DIFF
--- a/app/decorators/controllers/solidus_digital/spree/admin/orders_controller_decorator.rb
+++ b/app/decorators/controllers/solidus_digital/spree/admin/orders_controller_decorator.rb
@@ -8,7 +8,7 @@ module SolidusDigital
           load_order
           @order.reset_digital_links!
           flash[:notice] = I18n.t('spree.digitals.downloads_reset')
-          redirect_to spree.admin_order_path(@order)
+          redirect_to spree.edit_admin_order_path(@order)
         end
 
         ::Spree::Admin::OrdersController.prepend self

--- a/spec/controllers/admin/orders_controller_spec.rb
+++ b/spec/controllers/admin/orders_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Spree::Admin::OrdersController do
           digital_link.reload
         end.to change(digital_link, :access_counter).to(0)
 
-        expect(response).to redirect_to(spree.admin_order_path(order))
+        expect(response).to redirect_to(spree.edit_admin_order_path(order))
       end
     end
   end


### PR DESCRIPTION
Hello

I notice that when the admin user clicks on `reset_digitals`, the redirection is going to `admin_order_path` that resolves in `orders#show`. This method has no template by default in solidus and it fails. Usually the admin goes on the `orders#edit` to see the order and check it out. So this change is for that, when the `reset_digitals` is clicked the redirection goes now to `edit_admin_order_path` that resolves into `orders#edit`

Let me know what you think

Regards