### PR TITLE
Adds PermissionSets for Digital

### DIFF
--- a/app/models/solidus_digital/permission_sets/digital_display.rb
+++ b/app/models/solidus_digital/permission_sets/digital_display.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module SolidusDigital
+  module PermissionSets
+    class DigitalDisplay < ::Spree::PermissionSets::Base
+      def activate!
+        can [:display, :admin], ::Spree::Digital
+      end
+    end
+  end
+end

--- a/app/models/solidus_digital/permission_sets/digital_management.rb
+++ b/app/models/solidus_digital/permission_sets/digital_management.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module SolidusDigital
+  module PermissionSets
+    class DigitalManagement < ::Spree::PermissionSets::Base
+      def activate!
+        can :manage, ::Spree::Digital
+      end
+    end
+  end
+end

--- a/app/views/spree/admin/digitals/_form.html.erb
+++ b/app/views/spree/admin/digitals/_form.html.erb
@@ -4,38 +4,44 @@
       <legend><%= Spree::Variant.model_name.human %> "<%= variant.is_master ? "Master" : variant.options_text %>"</legend>
       <strong><%= I18n.t('spree.digitals.files') %>:</strong>
       <% if variant.digital? %>
-        <table class="table">
-          <thead>
-            <tr>
-              <th><%= I18n.t('spree.digitals.file_name') %></th>
-              <th class="actions"></th>
-            </tr>
-          </thead>
-          <tbody>
-          <% variant.digitals.each do |digital| %>
-            <tr>
-              <td><%= render digital %></td>
-              <td class="actions text-right">
-                <%= link_to_with_icon 'delete', I18n.t('spree.digitals.delete_file'), admin_product_digital_url(@product, digital), data: {confirm: I18n.t('spree.digitals.delete_file_confirmation', filename: digital.attachment_file_name)}, method: :delete, class: 'btn btn-danger btn-sm delete-resource' %>
-              </td>
-            </tr>
-          <% end %>
-          </tbody>
-        </table>
+        <% if can?(:display, Spree::Digital) %>
+          <table class="table">
+            <thead>
+              <tr>
+                <th><%= I18n.t('spree.digitals.file_name') %></th>
+                <th class="actions"></th>
+              </tr>
+            </thead>
+            <tbody>
+            <% variant.digitals.each do |digital| %>
+              <tr>
+                <td><%= render digital %></td>
+                <td class="actions text-right">
+                  <% if can?(:destroy, Spree::Digital) %>
+                    <%= link_to_with_icon 'delete', I18n.t('spree.digitals.delete_file'), admin_product_digital_url(@product, digital), data: {confirm: I18n.t('spree.digitals.delete_file_confirmation', filename: digital.attachment_file_name)}, method: :delete, class: 'btn btn-danger btn-sm delete-resource' %>
+                  <% end %>
+                </td>
+              </tr>
+            <% end %>
+            </tbody>
+          </table>
+        <% end %>
       <% else %>
         <%= I18n.t('spree.none') %>
       <% end %>
       <p class="form-buttons">
-        <%= f.field_container :file do %>
-          <%= f.label :file, I18n.t('spree.digitals.new_file') %> <span class="required">*</span><br/>
-          <%= f.file_field :attachment %>
-          <%= f.label :drm %>
-          <%= f.check_box :drm %>
-        <% end %>
+        <% if can?(:create, Spree::Digital) %>
+          <%= f.field_container :file do %>
+            <%= f.label :file, I18n.t('spree.digitals.new_file') %> <span class="required">*</span><br/>
+            <%= f.file_field :attachment %>
+            <%= f.label :drm %>
+            <%= f.check_box :drm %>
+          <% end %>
 
-        <%= hidden_field_tag 'digital[variant_id]', variant.id %>
-        <br>
-        <%= button_tag I18n.t('spree.digitals.upload'), :class => "btn-success" %>
+          <%= hidden_field_tag 'digital[variant_id]', variant.id %>
+          <br>
+          <%= button_tag I18n.t('spree.digitals.upload'), :class => "btn-success" %>
+        <% end %>
       </p>
     </fieldset>
   <% end %>

--- a/app/views/spree/admin/digitals/index.html.erb
+++ b/app/views/spree/admin/digitals/index.html.erb
@@ -6,10 +6,12 @@
     <%= render 'form', :variant => variant %>
   <% end %>
 <% else %>
- <span><%= t('spree.digitals.product_no_variants') %></span>
- <% if @product.master.digital? %>
-    <span><%= t('spree.digitals.product_with_variants') %></span>
-    <%= render @product.master.digitals %>
+  <span><%= t('spree.digitals.product_no_variants') %></span>
+  <% if @product.master.digital? %>
+    <% if can?(:display, Spree::Digital) %>
+      <span><%= t('spree.digitals.product_with_variants') %></span>
+      <%= render @product.master.digitals %>
+    <% end %>
   <% end %>
   <%= render 'form', :variant => @product.master %>
 <% end %>


### PR DESCRIPTION
Hello

I created a couple of permission sets for this extension in order to have more control of access on Digital for admin users. In that way we could have admin users to create, edit or read only Digital objects. It will integrate well with the extension https://github.com/boomerdigital/solidus_user_roles.

Let me know what you think

Happy to fix if you guys spot something wrong.